### PR TITLE
Feature/argument as struct

### DIFF
--- a/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
@@ -25,6 +25,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsLessThan_ArgumentValueIsLessThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsLessThan(1));
+        }
+
+        [TestMethod]
         public void IsLessThan_ArgumentValueEqualsValue_Throws()
         {
             var name = "name";
@@ -43,7 +50,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsLessThan(0));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsNotLessThan_NullArgumentValue_Throws()
@@ -70,6 +76,20 @@ namespace wimm.Guardian.UnitTests
             var ex =
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsNotLessThan(1));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsNotLessThan_ArgumentValueEqualsValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotLessThan(0));
+        }
+
+        [TestMethod]
+        public void IsNotLessThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsNotLessThan(0));
         }
 
         [TestMethod]
@@ -110,6 +130,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsGreaterThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsGreaterThan(0));
+        }
+
+        [TestMethod]
         public void IsNotGreaterThan_NullArgumentValue_Throws()
         {
             var argument = new Argument<string>("name", null);
@@ -127,6 +154,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotGreaterThan_ArgumentValueIsLessThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotGreaterThan(1));
+        }
+
+        [TestMethod]
+        public void IsNotGreaterThan_ArgumentValueEqualsValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotGreaterThan(0));
+        }
+
+        [TestMethod]
         public void IsNotGreaterThan_ArgumentValueIsGreaterThanValue_Throws()
         {
             var name = "name";
@@ -135,7 +176,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsNotGreaterThan(0));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsInRange_NullArgumentValue_Throws()
@@ -173,6 +213,27 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueEqualsMin_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueIsBetweenMinAndMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 2);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueEqualsMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 3);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
         }
 
         [TestMethod]
@@ -214,6 +275,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotInRange_ArgumentValueIsLessThanMin_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotInRange(1, 3));
+        }
+
+        [TestMethod]
         public void IsNotInRange_ArgumentValueEqualsMin_Throws()
         {
             var name = "name";
@@ -244,6 +312,13 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsNotInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsNotInRange_ArgumentValueIsGreaterThanMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 4);
+            Assert.AreEqual(argument, argument.IsNotInRange(1, 3));
         }
 
         [TestMethod]
@@ -296,6 +371,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsBetween_ArgumentValueIsBetweenAAndB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 2);
+            Assert.AreEqual(argument, argument.IsBetween(1, 3));
+        }
+
+        [TestMethod]
         public void IsBetween_ArgumentValueEqualsB_Throws()
         {
             var name = "name";
@@ -316,7 +398,6 @@ namespace wimm.Guardian.UnitTests
                     () => argument.IsBetween(1, 3));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsNotBetween_NullArgumentValue_Throws()
@@ -346,6 +427,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotBetween_ArgumentValueIsLessThanA_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueEqualsA_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
         public void IsNotBetween_ArgumentValueIsBetweenAAndB_Throws()
         {
             var name = "name";
@@ -356,5 +451,18 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueEqualsB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 3);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueIsGreaterThanB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 4);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
     }
 }

--- a/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
@@ -8,15 +8,6 @@ namespace wimm.Guardian.UnitTests
     public class ArgumentRangeExtensionsTests
     {
         [TestMethod]
-        public void IsLessThan_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsLessThan(0));
-            Assert.AreEqual("target", ex.ParamName);
-        }
-
-        [TestMethod]
         public void IsLessThan_NullArgumentValue_Throws()
         {
             var argument = new Argument<string>("name", null);
@@ -31,13 +22,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentNullException>(
                     () => argument.IsLessThan(null as string));
             Assert.AreEqual("value", ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsLessThan_ArgumentValueIsLessThanValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsLessThan(1));
         }
 
         [TestMethod]
@@ -60,14 +44,6 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
-        [TestMethod]
-        public void IsNotLessThan_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsNotLessThan(0));
-            Assert.AreEqual("target", ex.ParamName);
-        }
 
         [TestMethod]
         public void IsNotLessThan_NullArgumentValue_Throws()
@@ -94,29 +70,6 @@ namespace wimm.Guardian.UnitTests
             var ex =
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsNotLessThan(1));
             Assert.AreEqual(name, ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotLessThan_ArgumentValueEqualsValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsNotLessThan(0));
-        }
-
-        [TestMethod]
-        public void IsNotLessThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 1);
-            Assert.AreSame(argument, argument.IsNotLessThan(0));
-        }
-
-        [TestMethod]
-        public void IsGreaterThan_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsGreaterThan(0));
-            Assert.AreEqual("target", ex.ParamName);
         }
 
         [TestMethod]
@@ -157,22 +110,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsGreaterThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 1);
-            Assert.AreSame(argument, argument.IsGreaterThan(0));
-        }
-
-        [TestMethod]
-        public void IsNotGreaterThan_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsNotGreaterThan(0));
-            Assert.AreEqual("target", ex.ParamName);
-        }
-
-        [TestMethod]
         public void IsNotGreaterThan_NullArgumentValue_Throws()
         {
             var argument = new Argument<string>("name", null);
@@ -190,20 +127,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsNotGreaterThan_ArgumentValueIsLessThanValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsNotGreaterThan(1));
-        }
-
-        [TestMethod]
-        public void IsNotGreaterThan_ArgumentValueEqualsValue_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsNotGreaterThan(0));
-        }
-
-        [TestMethod]
         public void IsNotGreaterThan_ArgumentValueIsGreaterThanValue_Throws()
         {
             var name = "name";
@@ -213,14 +136,6 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
-        [TestMethod]
-        public void IsInRange_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsInRange(0, 1));
-            Assert.AreEqual("target", ex.ParamName);
-        }
 
         [TestMethod]
         public void IsInRange_NullArgumentValue_Throws()
@@ -261,27 +176,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsInRange_ArgumentValueEqualsMin_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 1);
-            Assert.AreSame(argument, argument.IsInRange(1, 3));
-        }
-
-        [TestMethod]
-        public void IsInRange_ArgumentValueIsBetweenMinAndMax_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 2);
-            Assert.AreSame(argument, argument.IsInRange(1, 3));
-        }
-
-        [TestMethod]
-        public void IsInRange_ArgumentValueEqualsMax_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 3);
-            Assert.AreSame(argument, argument.IsInRange(1, 3));
-        }
-
-        [TestMethod]
         public void IsInRange_ArgumentValueIsGreaterThanMax_Throws()
         {
             var name = "name";
@@ -290,15 +184,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotInRange_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsNotInRange(0, 1));
-            Assert.AreEqual("target", ex.ParamName);
         }
 
         [TestMethod]
@@ -326,13 +211,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentNullException>(
                     () => argument.IsNotInRange("", null));
             Assert.AreEqual("max", ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotInRange_ArgumentValueIsLessThanMin_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsNotInRange(1, 3));
         }
 
         [TestMethod]
@@ -366,22 +244,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsNotInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotInRange_ArgumentValueIsGreaterThanMax_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 4);
-            Assert.AreSame(argument, argument.IsNotInRange(1, 3));
-        }
-
-        [TestMethod]
-        public void IsBetween_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsBetween(0, 1));
-            Assert.AreEqual("target", ex.ParamName);
         }
 
         [TestMethod]
@@ -434,13 +296,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsBetween_ArgumentValueIsBetweenAAndB_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 2);
-            Assert.AreSame(argument, argument.IsBetween(1, 3));
-        }
-
-        [TestMethod]
         public void IsBetween_ArgumentValueEqualsB_Throws()
         {
             var name = "name";
@@ -462,14 +317,6 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
-        [TestMethod]
-        public void IsNotBetween_NullTarget_Throws()
-        {
-            var ex =
-                 Assert.ThrowsException<ArgumentNullException>(
-                     () => (null as Argument<int>).IsNotBetween(0, 1));
-            Assert.AreEqual("target", ex.ParamName);
-        }
 
         [TestMethod]
         public void IsNotBetween_NullArgumentValue_Throws()
@@ -499,20 +346,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsNotBetween_ArgumentValueIsLessThanA_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 0);
-            Assert.AreSame(argument, argument.IsNotBetween(1, 3));
-        }
-
-        [TestMethod]
-        public void IsNotBetween_ArgumentValueEqualsA_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 1);
-            Assert.AreSame(argument, argument.IsNotBetween(1, 3));
-        }
-
-        [TestMethod]
         public void IsNotBetween_ArgumentValueIsBetweenAAndB_Throws()
         {
             var name = "name";
@@ -523,18 +356,5 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
-        [TestMethod]
-        public void IsNotBetween_ArgumentValueEqualsB_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 3);
-            Assert.AreSame(argument, argument.IsNotBetween(1, 3));
-        }
-
-        [TestMethod]
-        public void IsNotBetween_ArgumentValueIsGreaterThanB_ReturnsTarget()
-        {
-            var argument = new Argument<int>("name", 4);
-            Assert.AreSame(argument, argument.IsNotBetween(1, 3));
-        }
     }
 }

--- a/wimm.Guardian.UnitTests/ArgumentTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentTests.cs
@@ -66,11 +66,5 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual("name", ex.ParamName);
         }
         
-        [TestMethod]
-        public void IsNotNull_ValueIsNotNull_ReturnsSelf()
-        {
-            var argument = new Argument<object>("name", new object());
-            Assert.AreSame(argument, argument.IsNotNull());
-        }
     }
 }

--- a/wimm.Guardian.UnitTests/ArgumentTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentTests.cs
@@ -66,5 +66,11 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual("name", ex.ParamName);
         }
         
+        [TestMethod]
+        public void IsNotNull_ValueIsNotNull_ReturnsSelf()
+        {
+            var argument = new Argument<object>("name", new object());
+            Assert.AreEqual(argument, argument.IsNotNull());
+        }
     }
 }

--- a/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
@@ -12,7 +12,6 @@ namespace wimm.Guardian.UnitTests
         protected abstract T Negative { get; }
         protected abstract T Positive { get; }
 
-
         [TestMethod]
         public void IsPositive_Negative_Throws()
         {
@@ -31,6 +30,20 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => new Argument<T>(name, Zero).IsPositive());
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsPositive_Positive_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Positive);
+            Assert.AreEqual(argument, argument.IsPositive());
+        }
+
+        [TestMethod]
+        public void IsNegative_Negative_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Negative);
+            Assert.AreEqual(argument, argument.IsNegative());
         }
 
         [TestMethod]
@@ -54,6 +67,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotPositive_Negative_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Negative);
+            Assert.AreEqual(argument, argument.IsNotPositive());
+        }
+
+        [TestMethod]
+        public void IsNotPositive_Zero_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Zero);
+            Assert.AreEqual(argument, argument.IsNotPositive());
+        }
+
+        [TestMethod]
         public void IsNotPositive_Positive_Throws()
         {
             var name = "name";
@@ -73,6 +100,19 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
+        [TestMethod]
+        public void IsNotNegative_Zero_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Zero);
+            Assert.AreEqual(argument, argument.IsNotNegative());
+        }
+
+        [TestMethod]
+        public void IsNotNegative_Positive_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Positive);
+            Assert.AreEqual(argument, argument.IsNotNegative());
+        }
     }
 
     [TestClass]

--- a/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
@@ -12,14 +12,6 @@ namespace wimm.Guardian.UnitTests
         protected abstract T Negative { get; }
         protected abstract T Positive { get; }
 
-        [TestMethod]
-        public void IsPositive_NullTarget_Throws()
-        {
-            var ex =
-                Assert.ThrowsException<ArgumentNullException>(
-                    () => (null as Argument<T>).IsPositive());
-            Assert.AreEqual("target", ex.ParamName);
-        }
 
         [TestMethod]
         public void IsPositive_Negative_Throws()
@@ -39,29 +31,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => new Argument<T>(name, Zero).IsPositive());
             Assert.AreEqual(name, ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsPositive_Positive_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Positive);
-            Assert.AreSame(argument, argument.IsPositive());
-        }
-
-        [TestMethod]
-        public void IsNegative_NullTarget_Throws()
-        {
-            var ex =
-                Assert.ThrowsException<ArgumentNullException>(
-                    () => (null as Argument<T>).IsNegative());
-            Assert.AreEqual("target", ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNegative_Negative_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Negative);
-            Assert.AreSame(argument, argument.IsNegative());
         }
 
         [TestMethod]
@@ -85,29 +54,6 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
-        public void IsNotPositive_NullTarget_Throws()
-        {
-            var ex =
-                Assert.ThrowsException<ArgumentNullException>(
-                    () => (null as Argument<T>).IsNotPositive());
-            Assert.AreEqual("target", ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotPositive_Negative_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Negative);
-            Assert.AreSame(argument, argument.IsNotPositive());
-        }
-
-        [TestMethod]
-        public void IsNotPositive_Zero_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Zero);
-            Assert.AreSame(argument, argument.IsNotPositive());
-        }
-
-        [TestMethod]
         public void IsNotPositive_Positive_Throws()
         {
             var name = "name";
@@ -115,15 +61,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => new Argument<T>(name, Positive).IsNotPositive());
             Assert.AreEqual(name, ex.ParamName);
-        }
-
-        [TestMethod]
-        public void IsNotNegative_NullTarget_Throws()
-        {
-            var ex =
-                Assert.ThrowsException<ArgumentNullException>(
-                    () => (null as Argument<T>).IsNotNegative());
-            Assert.AreEqual("target", ex.ParamName);
         }
 
         [TestMethod]
@@ -136,19 +73,6 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
-        [TestMethod]
-        public void IsNotNegative_Zero_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Zero);
-            Assert.AreSame(argument, argument.IsNotNegative());
-        }
-
-        [TestMethod]
-        public void IsNotNegative_Positive_ReturnsTarget()
-        {
-            var argument = new Argument<T>("name", Positive);
-            Assert.AreSame(argument, argument.IsNotNegative());
-        }
     }
 
     [TestClass]

--- a/wimm.Guardian.UnitTests/wimm.Guardian.UnitTests.csproj
+++ b/wimm.Guardian.UnitTests/wimm.Guardian.UnitTests.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\wimm.Guardian\wimm.Guardian.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace wimm.Guardian
 {
@@ -37,55 +36,16 @@ namespace wimm.Guardian
         /// Throws an <see cref="ArgumentNullException"/> if <see cref="Value"/> is <c>null</c>.
         /// </summary>
         /// <exception cref="InvalidOperationException"> 
-        /// if defualt of <typeparamref name="T"/> is not null
+        /// The default value of <typeparamref name="T"/> is not null.
         /// </exception>
         /// <returns>The <see cref="Argument{T}"/>.</returns>
         public Argument<T> IsNotNull()
         {
             if (default(T) != null)
                 throw new InvalidOperationException($"{nameof(T)} must be nullable to check for null");
-
-            // TODO: Find a way to constrain this to nullables or throw for non-nullable types.
+            
             if (Value == null) throw new ArgumentNullException(Name);
             return this;
         }
-
-        // TODO: Remove equality overloads. 
-        // Tests should just verify the member values, 2 arguments with the same name and value
-        // aren't neccessarily the same argument.
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public override bool Equals(object obj)
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        {
-
-            if (obj is Argument<T> subject)
-            {
-                return Name == subject.Name &&
-                   EqualityComparer<T>.Default.Equals(Value, subject.Value);
-            }
-
-            return false;
-        }
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public override int GetHashCode()
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        {
-            var hashCode = -244751520;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
-            hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Value);
-            return hashCode;
-        }
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public static bool operator ==(Argument<T> argument1, Argument<T> argument2) =>
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-            EqualityComparer<Argument<T>>.Default.Equals(argument1, argument2);
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public static bool operator !=(Argument<T> argument1, Argument<T> argument2) =>
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-             !(argument1 == argument2);
     }
 }

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -7,7 +7,7 @@ namespace wimm.Guardian
     /// A method argument.
     /// </summary>
     /// <typeparam name="T">The type of the arugment.</typeparam>
-    public class Argument<T>
+    public struct Argument<T>
     {
         /// <summary>
         /// The argument name.
@@ -52,10 +52,14 @@ namespace wimm.Guardian
         public override bool Equals(object obj)
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
-            var subject = obj as Argument<T>;
-            return subject != null &&
-                   Name == subject.Name &&
+
+            if (obj is Argument<T> subject)
+            {
+                return Name == subject.Name &&
                    EqualityComparer<T>.Default.Equals(Value, subject.Value);
+            }
+
+            return false;
         }
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -36,6 +36,9 @@ namespace wimm.Guardian
         /// <summary>
         /// Throws an <see cref="ArgumentNullException"/> if <see cref="Value"/> is <c>null</c>.
         /// </summary>
+        /// <exception cref="InvalidOperationException"> 
+        /// if defualt of <typeparamref name="T"/> is not null
+        /// </exception>
         /// <returns>The <see cref="Argument{T}"/>.</returns>
         public Argument<T> IsNotNull()
         {

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -39,6 +39,9 @@ namespace wimm.Guardian
         /// <returns>The <see cref="Argument{T}"/>.</returns>
         public Argument<T> IsNotNull()
         {
+            if (default(T) != null)
+                throw new InvalidOperationException($"{nameof(T)} must be nullable to check for null");
+
             // TODO: Find a way to constrain this to nullables or throw for non-nullable types.
             if (Value == null) throw new ArgumentNullException(Name);
             return this;

--- a/wimm.Guardian/ArgumentRangeExtensions.cs
+++ b/wimm.Guardian/ArgumentRangeExtensions.cs
@@ -251,11 +251,6 @@ namespace wimm.Guardian
                     $"Cannot compare against null-valued Argument.");
         }
 
-        private static void IsNotNullIfNullable<T>(this Argument<T> argument)
-        {
-            if (default(T) == null)
-                argument.IsNotNull();
-        }
 
     }
 }

--- a/wimm.Guardian/ArgumentRangeExtensions.cs
+++ b/wimm.Guardian/ArgumentRangeExtensions.cs
@@ -24,9 +24,8 @@ namespace wimm.Guardian
         public static Argument<T> IsLessThan<T>(this Argument<T> target, T value)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            value.Require(nameof(value)).IsNotNull();
+            value.Require(nameof(value)).IsNotNullIfNullable();
 
             if (!target.Value.IsLessThan(value))
                 throw new ArgumentOutOfRangeException(target.Name, $"Must be less than {value}.");
@@ -51,9 +50,8 @@ namespace wimm.Guardian
         public static Argument<T> IsNotLessThan<T>(this Argument<T> target, T value)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            value.Require(nameof(value)).IsNotNull();
+            value.Require(nameof(value)).IsNotNullIfNullable();
 
             if (target.Value.IsLessThan(value))
                 throw new ArgumentOutOfRangeException(target.Name, $"Must not be less than {value}.");
@@ -78,9 +76,8 @@ namespace wimm.Guardian
         public static Argument<T> IsGreaterThan<T>(this Argument<T> target, T value)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            value.Require(nameof(value)).IsNotNull();
+            value.Require(nameof(value)).IsNotNullIfNullable();
 
             if (!target.Value.IsGreaterThan(value))
                 throw new ArgumentOutOfRangeException(target.Name, $"Must be greater than {value}.");
@@ -105,9 +102,8 @@ namespace wimm.Guardian
         public static Argument<T> IsNotGreaterThan<T>(this Argument<T> target, T value)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            value.Require(nameof(value)).IsNotNull();
+            value.Require(nameof(value)).IsNotNullIfNullable();
 
             if (target.Value.IsGreaterThan(value))
                 throw new ArgumentOutOfRangeException(target.Name, $"Must not be greater than {value}.");
@@ -135,10 +131,9 @@ namespace wimm.Guardian
         public static Argument<T> IsInRange<T>(this Argument<T> target, T min, T max)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            min.Require(nameof(min)).IsNotNull();
-            max.Require(nameof(max)).IsNotNull();
+            min.Require(nameof(min)).IsNotNullIfNullable();
+            max.Require(nameof(max)).IsNotNullIfNullable();
 
             return target.IsNotLessThan(min).IsNotGreaterThan(max);
         }
@@ -163,10 +158,9 @@ namespace wimm.Guardian
         public static Argument<T> IsNotInRange<T>(this Argument<T> target, T min, T max)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            min.Require(nameof(min)).IsNotNull();
-            max.Require(nameof(max)).IsNotNull();
+            min.Require(nameof(min)).IsNotNullIfNullable();
+            max.Require(nameof(max)).IsNotNullIfNullable();
 
             if (!(target.Value.IsLessThan(min) || target.Value.IsGreaterThan(max)))
                 throw new ArgumentOutOfRangeException(
@@ -200,10 +194,9 @@ namespace wimm.Guardian
         public static Argument<T> IsBetween<T>(this Argument<T> target, T floor, T ceiling)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            floor.Require(nameof(floor)).IsNotNull();
-            ceiling.Require(nameof(ceiling)).IsNotNull();
+            floor.Require(nameof(floor)).IsNotNullIfNullable();
+            ceiling.Require(nameof(ceiling)).IsNotNullIfNullable(); 
 
             return target.IsGreaterThan(floor).IsLessThan(ceiling);
         }
@@ -232,10 +225,10 @@ namespace wimm.Guardian
         public static Argument<T> IsNotBetween<T>(this Argument<T> target, T floor, T ceiling)
             where T : IComparable<T>
         {
-            target.Require(nameof(target)).IsNotNull();
             target.AssertArgumentIsComparable();
-            floor.Require(nameof(floor)).IsNotNull();
-            ceiling.Require(nameof(ceiling)).IsNotNull();
+
+            floor.Require(nameof(floor)).IsNotNullIfNullable();
+            ceiling.Require(nameof(ceiling)).IsNotNullIfNullable();
 
             if (target.Value.IsGreaterThan(floor) && target.Value.IsLessThan(ceiling))
                 throw new ArgumentOutOfRangeException(
@@ -257,5 +250,12 @@ namespace wimm.Guardian
                 throw new InvalidOperationException(
                     $"Cannot compare against null-valued Argument.");
         }
+
+        private static void IsNotNullIfNullable<T>(this Argument<T> argument)
+        {
+            if (default(T) == null)
+                argument.IsNotNull();
+        }
+
     }
 }

--- a/wimm.Guardian/ArgumentRangeExtensions.cs
+++ b/wimm.Guardian/ArgumentRangeExtensions.cs
@@ -15,9 +15,6 @@ namespace wimm.Guardian
         /// <param name="target">The target.</param>
         /// <param name="value">The <typeparamref name="T"/> to compare against.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, or <paramref name="value"/> is <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -41,9 +38,6 @@ namespace wimm.Guardian
         /// <param name="target">The target.</param>
         /// <param name="value">The <typeparamref name="T"/> to compare against.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, or <paramref name="value"/> is <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -67,9 +61,6 @@ namespace wimm.Guardian
         /// <param name="target">The target.</param>
         /// <param name="value">The <typeparamref name="T"/> to compare against.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, or <paramref name="value"/> is <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -93,9 +84,6 @@ namespace wimm.Guardian
         /// <param name="target">The target.</param>
         /// <param name="value">The <typeparamref name="T"/> to compare against.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, or <paramref name="value"/> is <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -121,10 +109,6 @@ namespace wimm.Guardian
         /// <param name="min">The minimum allowed value for <paramref name="target"/>.</param>
         /// <param name="max">The maximum allowed value for <paramref name="target"/>.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, <paramref name="min"/>, or <paramref name="max"/> is
-        /// <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -148,10 +132,6 @@ namespace wimm.Guardian
         /// <param name="min">The minimum allowed value for <paramref name="target"/>.</param>
         /// <param name="max">The maximum allowed value for <paramref name="target"/>.</param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, <paramref name="min"/>, or <paramref name="max"/> is
-        /// <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -184,10 +164,6 @@ namespace wimm.Guardian
         /// The value that <paramref name="target"/> must be less than.
         /// </param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, <paramref name="floor"/>, or <paramref name="ceiling"/> is
-        /// <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>
@@ -215,10 +191,6 @@ namespace wimm.Guardian
         /// The ceiling of the range that <paramref name="target"/>'s value must not be in.
         /// </param>
         /// <returns><paramref name="target"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/>, <paramref name="floor"/>, or <paramref name="ceiling"/> is
-        /// <c>null</c>.
-        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="Argument{T}.Value"/> member of <paramref name="target"/> is <c>null</c>.
         /// </exception>

--- a/wimm.Guardian/GenericExtensions.cs
+++ b/wimm.Guardian/GenericExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace wimm.Guardian
+{
+    internal static class GenericExtensions
+    {
+        internal static void IsNotNullIfNullable<T>(this Argument<T> argument)
+        {
+            if (default(T) == null)
+                argument.IsNotNull();
+        }
+    }
+}

--- a/wimm.Guardian/NumericArgumentExtensions.cs
+++ b/wimm.Guardian/NumericArgumentExtensions.cs
@@ -29,9 +29,6 @@ namespace wimm.Guardian
         /// <exception cref="TypeArgumentException">
         /// <typeparamref name="T"/> is not a valid numeric type.
         /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/> is <c>null</c>.
-        /// </exception>
         public static Argument<T> IsPositive<T>(this Argument<T> target) where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
@@ -47,9 +44,6 @@ namespace wimm.Guardian
         /// <exception cref="TypeArgumentException">
         /// <typeparamref name="T"/> is not a valid numeric type.
         /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/> is <c>null</c>.
-        /// </exception>
         public static Argument<T> IsNegative<T>(this Argument<T> target) where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
@@ -64,9 +58,6 @@ namespace wimm.Guardian
         /// <returns><paramref name="target"/>.</returns>
         /// <exception cref="TypeArgumentException">
         /// <typeparamref name="T"/> is not a valid numeric type.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/> is <c>null</c>.
         /// </exception>
         public static Argument<T> IsNotPositive<T>(this Argument<T> target)
             where T : IComparable<T>
@@ -84,9 +75,6 @@ namespace wimm.Guardian
         /// <exception cref="TypeArgumentException">
         /// <typeparamref name="T"/> is not a valid numeric type.
         /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="target"/> is <c>null</c>.
-        /// </exception>
         public static Argument<T> IsNotNegative<T>(this Argument<T> target)
             where T : IComparable<T>
         {
@@ -96,6 +84,7 @@ namespace wimm.Guardian
 
         private static Argument<Type> IsSupportedTypeParam(this Argument<Type> target)
         {
+            
             if (!_supportedTypes.Contains(target.Value))
                 throw new TypeArgumentException(target.Name, target.Value);
             return target;

--- a/wimm.Guardian/NumericArgumentExtensions.cs
+++ b/wimm.Guardian/NumericArgumentExtensions.cs
@@ -35,7 +35,6 @@ namespace wimm.Guardian
         public static Argument<T> IsPositive<T>(this Argument<T> target) where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
-            target.Require(nameof(target)).IsNotNull();
             return target.IsGreaterThan(default(T));
         }
 
@@ -54,7 +53,6 @@ namespace wimm.Guardian
         public static Argument<T> IsNegative<T>(this Argument<T> target) where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
-            target.Require(nameof(target)).IsNotNull();
             return target.IsLessThan(default(T));
         }
 
@@ -74,7 +72,6 @@ namespace wimm.Guardian
             where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
-            target.Require(nameof(target)).IsNotNull();
             return target.IsNotGreaterThan(default(T));
         }
 
@@ -94,13 +91,11 @@ namespace wimm.Guardian
             where T : IComparable<T>
         {
             typeof(T).Require(nameof(T)).IsSupportedTypeParam();
-            target.Require(nameof(target)).IsNotNull();
             return target.IsNotLessThan(default(T));
         }
 
         private static Argument<Type> IsSupportedTypeParam(this Argument<Type> target)
         {
-            target.Require(nameof(target)).IsNotNull();
             if (!_supportedTypes.Contains(target.Value))
                 throw new TypeArgumentException(target.Name, target.Value);
             return target;


### PR DESCRIPTION
Converted Argument<T> to a struct based on average use case. Most things are going to be less than 16B so we get equivalent or better perf than classes and it saves a bunch of cascading null checks for methods that take in Argument<T>. 

I also added a nullability check in Argument<T>::IsNotNull because the default behaviour of null checks in C# (return false on == null for value types) is a heaping pile of garbage. Now you'll see an exception if you try to check null on Argument<int> or Argument<Argument<T>>

I added GenericExtensions.cs which includes an internal "IsNotNullIfNullable" extension which looks ugly in this font but in a good programming font is readable. I've changed it so that it checks that default(T) before calling argument.IsNotNull so that in generic methods you don't have to care about value vs ref vs nullable checking. Also I think the JIT will pull out all the default(T) == null since that's a compile time constant and just won't compile that branch. I havent decompiled the output though so don't trust me. SharkLab doesn't do generics really nicely. I think it would have done that regardless because == null should also be a compile time constant I'm just not sure that's guaranteed. From what I've been reading this is. Totally irrelevant since I basically did most of this so that I wouldn't have to check Argument<Argument<T>> for null ever because it makes me sad. 