### PR TITLE
Feature/argument as struct tweaks

### DIFF
--- a/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentRangeExtensionsTests.cs
@@ -25,6 +25,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsLessThan_ArgumentValueIsLessThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsLessThan(1));
+        }
+
+        [TestMethod]
         public void IsLessThan_ArgumentValueEqualsValue_Throws()
         {
             var name = "name";
@@ -43,7 +50,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsLessThan(0));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsNotLessThan_NullArgumentValue_Throws()
@@ -70,6 +76,20 @@ namespace wimm.Guardian.UnitTests
             var ex =
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsNotLessThan(1));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsNotLessThan_ArgumentValueEqualsValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotLessThan(0));
+        }
+
+        [TestMethod]
+        public void IsNotLessThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsNotLessThan(0));
         }
 
         [TestMethod]
@@ -110,6 +130,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsGreaterThan_ArgumentValueIsGreaterThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsGreaterThan(0));
+        }
+
+        [TestMethod]
         public void IsNotGreaterThan_NullArgumentValue_Throws()
         {
             var argument = new Argument<string>("name", null);
@@ -127,6 +154,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotGreaterThan_ArgumentValueIsLessThanValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotGreaterThan(1));
+        }
+
+        [TestMethod]
+        public void IsNotGreaterThan_ArgumentValueEqualsValue_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotGreaterThan(0));
+        }
+
+        [TestMethod]
         public void IsNotGreaterThan_ArgumentValueIsGreaterThanValue_Throws()
         {
             var name = "name";
@@ -135,7 +176,6 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(() => argument.IsNotGreaterThan(0));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsInRange_NullArgumentValue_Throws()
@@ -173,6 +213,27 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueEqualsMin_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueIsBetweenMinAndMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 2);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
+        }
+
+        [TestMethod]
+        public void IsInRange_ArgumentValueEqualsMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 3);
+            Assert.AreEqual(argument, argument.IsInRange(1, 3));
         }
 
         [TestMethod]
@@ -214,6 +275,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotInRange_ArgumentValueIsLessThanMin_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotInRange(1, 3));
+        }
+
+        [TestMethod]
         public void IsNotInRange_ArgumentValueEqualsMin_Throws()
         {
             var name = "name";
@@ -244,6 +312,13 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => argument.IsNotInRange(1, 3));
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsNotInRange_ArgumentValueIsGreaterThanMax_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 4);
+            Assert.AreEqual(argument, argument.IsNotInRange(1, 3));
         }
 
         [TestMethod]
@@ -296,6 +371,13 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsBetween_ArgumentValueIsBetweenAAndB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 2);
+            Assert.AreEqual(argument, argument.IsBetween(1, 3));
+        }
+
+        [TestMethod]
         public void IsBetween_ArgumentValueEqualsB_Throws()
         {
             var name = "name";
@@ -316,7 +398,6 @@ namespace wimm.Guardian.UnitTests
                     () => argument.IsBetween(1, 3));
             Assert.AreEqual(name, ex.ParamName);
         }
-
 
         [TestMethod]
         public void IsNotBetween_NullArgumentValue_Throws()
@@ -346,6 +427,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotBetween_ArgumentValueIsLessThanA_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 0);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueEqualsA_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 1);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
         public void IsNotBetween_ArgumentValueIsBetweenAAndB_Throws()
         {
             var name = "name";
@@ -356,5 +451,18 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueEqualsB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 3);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
+
+        [TestMethod]
+        public void IsNotBetween_ArgumentValueIsGreaterThanB_ReturnsTarget()
+        {
+            var argument = new Argument<int>("name", 4);
+            Assert.AreEqual(argument, argument.IsNotBetween(1, 3));
+        }
     }
 }

--- a/wimm.Guardian.UnitTests/ArgumentTests.cs
+++ b/wimm.Guardian.UnitTests/ArgumentTests.cs
@@ -66,5 +66,11 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual("name", ex.ParamName);
         }
         
+        [TestMethod]
+        public void IsNotNull_ValueIsNotNull_ReturnsSelf()
+        {
+            var argument = new Argument<object>("name", new object());
+            Assert.AreEqual(argument, argument.IsNotNull());
+        }
     }
 }

--- a/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/NumericExtensionsTests.cs
@@ -12,7 +12,6 @@ namespace wimm.Guardian.UnitTests
         protected abstract T Negative { get; }
         protected abstract T Positive { get; }
 
-
         [TestMethod]
         public void IsPositive_Negative_Throws()
         {
@@ -31,6 +30,20 @@ namespace wimm.Guardian.UnitTests
                 Assert.ThrowsException<ArgumentOutOfRangeException>(
                     () => new Argument<T>(name, Zero).IsPositive());
             Assert.AreEqual(name, ex.ParamName);
+        }
+
+        [TestMethod]
+        public void IsPositive_Positive_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Positive);
+            Assert.AreEqual(argument, argument.IsPositive());
+        }
+
+        [TestMethod]
+        public void IsNegative_Negative_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Negative);
+            Assert.AreEqual(argument, argument.IsNegative());
         }
 
         [TestMethod]
@@ -54,6 +67,20 @@ namespace wimm.Guardian.UnitTests
         }
 
         [TestMethod]
+        public void IsNotPositive_Negative_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Negative);
+            Assert.AreEqual(argument, argument.IsNotPositive());
+        }
+
+        [TestMethod]
+        public void IsNotPositive_Zero_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Zero);
+            Assert.AreEqual(argument, argument.IsNotPositive());
+        }
+
+        [TestMethod]
         public void IsNotPositive_Positive_Throws()
         {
             var name = "name";
@@ -73,6 +100,19 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(name, ex.ParamName);
         }
 
+        [TestMethod]
+        public void IsNotNegative_Zero_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Zero);
+            Assert.AreEqual(argument, argument.IsNotNegative());
+        }
+
+        [TestMethod]
+        public void IsNotNegative_Positive_ReturnsTarget()
+        {
+            var argument = new Argument<T>("name", Positive);
+            Assert.AreEqual(argument, argument.IsNotNegative());
+        }
     }
 
     [TestClass]

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -37,7 +37,7 @@ namespace wimm.Guardian
         /// Throws an <see cref="ArgumentNullException"/> if <see cref="Value"/> is <c>null</c>.
         /// </summary>
         /// <exception cref="InvalidOperationException"> 
-        /// if defualt of <typeparamref name="T"/> is not null
+        /// The default value of <typeparamref name="T"/> is not null.
         /// </exception>
         /// <returns>The <see cref="Argument{T}"/>.</returns>
         public Argument<T> IsNotNull()

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace wimm.Guardian
 {
@@ -44,48 +43,9 @@ namespace wimm.Guardian
         {
             if (default(T) != null)
                 throw new InvalidOperationException($"{nameof(T)} must be nullable to check for null");
-
-            // TODO: Find a way to constrain this to nullables or throw for non-nullable types.
+            
             if (Value == null) throw new ArgumentNullException(Name);
             return this;
         }
-
-        // TODO: Remove equality overloads. 
-        // Tests should just verify the member values, 2 arguments with the same name and value
-        // aren't neccessarily the same argument.
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public override bool Equals(object obj)
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        {
-
-            if (obj is Argument<T> subject)
-            {
-                return Name == subject.Name &&
-                   EqualityComparer<T>.Default.Equals(Value, subject.Value);
-            }
-
-            return false;
-        }
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public override int GetHashCode()
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        {
-            var hashCode = -244751520;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
-            hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Value);
-            return hashCode;
-        }
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public static bool operator ==(Argument<T> argument1, Argument<T> argument2) =>
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-            EqualityComparer<Argument<T>>.Default.Equals(argument1, argument2);
-
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        public static bool operator !=(Argument<T> argument1, Argument<T> argument2) =>
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-             !(argument1 == argument2);
     }
 }


### PR DESCRIPTION
Instead of removing the sameness tests I thought they could just be changed to equality tests. The point of them is to ensure that successive validations see the same name/value so, in the case of a struct, the value equality is sufficient.