### PR TITLE
Feature/enum arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+
+wimm\.Guardian/GlobalSuppressions\.cs

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guardian.UnitTests
+{
+    [TestClass]
+    public class EnumArgumentExtensionsTests
+    {
+        [TestMethod]
+        public void IsDefined_ValueUndefined_Throws()
+        {
+            var underTest = new Argument<TestEnum>("Doot", (TestEnum)(int.MaxValue));
+            Assert.ThrowsException<InvalidEnumArgumentException>(() => underTest.IsDefined());
+        }
+
+        [TestMethod]
+        public void IsDefined_ValueNotEnum_Throws()
+        {
+            var underTest = new Argument<DateTime>("Doot", DateTime.Now);
+            Assert.ThrowsException<TypeArgumentException>(() => underTest.IsDefined());
+        }
+
+        [TestMethod]
+        public void IsDefined_ValueDefined_ReturnsSameValue()
+        {
+            var underTest = new Argument<TestEnum>("Doot", TestEnum.Yes);
+            var res = underTest.IsDefined();
+
+            Assert.AreEqual(res.Value, underTest.Value);
+        }
+
+        private enum TestEnum
+        {
+            Yes,
+            No
+        }
+    }
+
+
+}

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace wimm.Guardian.UnitTests
         public void IsDefined_ValueUndefined_Throws()
         {
             var underTest = new Argument<TestEnum>("Doot", (TestEnum)(int.MaxValue));
-            Assert.ThrowsException<InvalidEnumArgumentException>(() => underTest.IsDefined());
+            Assert.ThrowsException<EnumArgumentOutOfRangeException>(() => underTest.IsDefined());
         }
 
         [TestMethod]

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -12,24 +12,24 @@ namespace wimm.Guardian.UnitTests
     public class EnumArgumentExtensionsTests
     {
         [TestMethod]
-        public void IsDefined_ValueUndefined_Throws()
+        public void IsDefinedEnum_ValueUndefined_Throws()
         {
             var underTest = new Argument<TestEnum>("Doot", (TestEnum)(int.MaxValue));
-            Assert.ThrowsException<EnumArgumentOutOfRangeException>(() => underTest.IsDefined());
+            Assert.ThrowsException<EnumArgumentOutOfRangeException>(() => underTest.IsDefinedEnum());
         }
 
         [TestMethod]
-        public void IsDefined_ValueNotEnum_Throws()
+        public void IsDefinedEnum_ValueNotEnum_Throws()
         {
             var underTest = new Argument<DateTime>("Doot", DateTime.Now);
-            Assert.ThrowsException<TypeArgumentException>(() => underTest.IsDefined());
+            Assert.ThrowsException<TypeArgumentException>(() => underTest.IsDefinedEnum());
         }
 
         [TestMethod]
-        public void IsDefined_ValueDefined_ReturnsSameValue()
+        public void IsDefinedEnum_ValueDefined_ReturnsSameValue()
         {
             var underTest = new Argument<TestEnum>("Doot", TestEnum.Yes);
-            var res = underTest.IsDefined();
+            var res = underTest.IsDefinedEnum();
 
             Assert.AreEqual(res.Value, underTest.Value);
         }

--- a/wimm.Guardian/Argument.cs
+++ b/wimm.Guardian/Argument.cs
@@ -11,12 +11,12 @@ namespace wimm.Guardian
         /// <summary>
         /// The argument name.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The argument value.
         /// </summary>
-        public T Value { get; private set; }
+        public T Value { get; }
 
         /// <summary>
         /// Initializes a new a <see cref="Argument{T}"/>.

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -18,7 +18,7 @@ namespace wimm.Guardian
         /// correspond with the enum's predefined values
         /// </summary>
         /// <typeparam name="T"> The enum type to be tested </typeparam>
-        /// <param name="argument"> And argument containing the value to be checked </param>
+        /// <param name="argument"> An argument containing the value to be checked </param>
         /// <returns> A copy of the input <see cref="Argument{T}"/> </returns>
         /// <exception cref="TypeArgumentException"> 
         /// The input type <typeparamref name="T"/> is not an enum type

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -33,7 +33,7 @@ namespace wimm.Guardian
             if (!typeof(T).GetTypeInfo().IsEnum)
                 throw new TypeArgumentException(nameof(T), typeof(T));
 
-            if (!Enum.IsDefined(argument.Value.GetType(), argument.Value))
+            if (!Enum.IsDefined(typeof(T), argument.Value))
                 throw new EnumArgumentOutOfRangeException(
                    argument.Name, typeof(T), (int)(ValueType)argument.Value);
 

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -27,7 +27,8 @@ namespace wimm.Guardian
         /// The value of <paramref name="argument"/> does not match the value of any defined value 
         /// of <paramref name="argument"/>
         /// </exception>
-        public static Argument<T> IsDefined<T>(this Argument<T> argument) where T : struct, IComparable
+        public static Argument<T> IsDefinedEnum<T>(this Argument<T> argument) 
+            where T : struct, IComparable
         {
             if (!typeof(T).GetTypeInfo().IsEnum)
                 throw new TypeArgumentException(nameof(T), typeof(T));

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -14,11 +14,19 @@ namespace wimm.Guardian
     public static class EnumArgumentExtensions
     {
         /// <summary>
-        /// TODO:CN
+        /// Throws an <see cref="EnumArgumentOutOfRangeException"/> if the enum argument does not
+        /// correspond with the enum's predefined values
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="argument"></param>
-        /// <returns></returns>
+        /// <typeparam name="T"> The enum type to be tested </typeparam>
+        /// <param name="argument"> And argument containing the value to be checked </param>
+        /// <returns> A copy of the input <see cref="Argument{T}"/> </returns>
+        /// <exception cref="TypeArgumentException"> 
+        /// The input type <typeparamref name="T"/> is not an enum type
+        /// </exception>
+        /// <exception cref="EnumArgumentOutOfRangeException">
+        /// The value of <paramref name="argument"/> does not match the value of any defined value 
+        /// of <paramref name="argument"/>
+        /// </exception>
         public static Argument<T> IsDefined<T>(this Argument<T> argument) where T : struct, IComparable
         {
             if (!typeof(T).GetTypeInfo().IsEnum)

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -25,7 +25,7 @@ namespace wimm.Guardian
         /// </exception>
         /// <exception cref="EnumArgumentOutOfRangeException">
         /// The value of <paramref name="argument"/> does not match the value of any defined value 
-        /// of <paramref name="argument"/>
+        /// of <typeparamref name="T"/>
         /// </exception>
         public static Argument<T> IsDefinedEnum<T>(this Argument<T> argument) 
             where T : struct, IComparable

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace wimm.Guardian
+{
+    /// <summary>
+    /// Argument validation methods for enums
+    /// </summary>
+    public static class EnumArgumentExtensions
+    {
+        /// <summary>
+        /// TODO:CN
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="argument"></param>
+        /// <returns></returns>
+        public static Argument<T> IsDefined<T>(this Argument<T> argument) where T : struct, IComparable
+        {
+            if (!typeof(T).GetTypeInfo().IsEnum)
+                throw new TypeArgumentException(nameof(T), typeof(T));
+
+            if (!Enum.IsDefined(argument.Value.GetType(), argument.Value))
+                throw new EnumArgumentOutOfRangeException(
+                   argument.Name, typeof(T), (int)(ValueType)argument.Value);
+
+            return argument;
+
+        }
+    }
+}

--- a/wimm.Guardian/EnumArgumentOutOfRangeException.cs
+++ b/wimm.Guardian/EnumArgumentOutOfRangeException.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guardian
+{
+    /// <summary>
+    /// An exception to indicate that an enum arguments values fall outside the set values for that enum
+    /// </summary>
+    public class EnumArgumentOutOfRangeException : Exception
+    {
+        private const string _defaultMessage = "An enum value was provided as an argument but the value" +
+            "was not a value of the enumeration";
+
+        /// <summary>
+        /// The enum type the value was tested against
+        /// </summary>
+        public Type EnumType { get; }
+        
+        /// <summary>
+        /// The name of the argument
+        /// </summary>
+        public string ArgumentName { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="EnumArgumentOutOfRangeException"/> with no message
+        /// </summary>
+        public EnumArgumentOutOfRangeException() : base() { }
+
+        /// <summary>
+        /// Creates a new <see cref="EnumArgumentOutOfRangeException"/> with the specified message
+        /// </summary>
+        /// <param name="message"> A message to be included in the exception </param>
+        public EnumArgumentOutOfRangeException(string message) : base(message) { }
+
+        /// <summary>
+        /// Creates a new <see cref="EnumArgumentOutOfRangeException"/> with a formatted message indicating
+        /// the name, type and offending value
+        /// </summary>
+        /// <param name="argument">The name of the argument that was tested </param>
+        /// <param name="enumType"> 
+        /// The type of enum that <paramref name="value"/> was supposed to represent
+        /// </param>
+        /// <param name="value"> 
+        /// The boxed value that fell outside of the range of values for <paramref name="enumType"/>
+        /// </param>
+        public EnumArgumentOutOfRangeException(string argument, Type enumType, object  value) 
+            : base(FormatMessage(argument,enumType,value))
+        {
+            ArgumentName = argument;
+            EnumType = enumType;
+        }
+
+        private static string FormatMessage(string parameter, Type enumType, object value)
+        {
+            return $"The value '{value}' was provided as the argument '{parameter}' but the" +
+                $" value was not a value of the enumeration '{enumType.GetTypeInfo().Name}'";
+        }
+
+    }
+}

--- a/wimm.Guardian/EnumArgumentOutOfRangeException.cs
+++ b/wimm.Guardian/EnumArgumentOutOfRangeException.cs
@@ -10,7 +10,7 @@ namespace wimm.Guardian
     /// <summary>
     /// An exception to indicate that an enum arguments values fall outside the set values for that enum
     /// </summary>
-    public class EnumArgumentOutOfRangeException : Exception
+    public class EnumArgumentOutOfRangeException : ArgumentException
     {
         private const string _defaultMessage = "An enum value was provided as an argument but the value" +
             "was not a value of the enumeration";

--- a/wimm.Guardian/StringArgumentExtensions.cs
+++ b/wimm.Guardian/StringArgumentExtensions.cs
@@ -76,9 +76,11 @@ namespace wimm.Guardian
         /// </exception>
         public static Argument<string> IsNotEmpty(this Argument<string> target)
         {
+            if (target.Value == null)
+                return target;
+
             if (target.Value.Length == 0)
-                throw new ArgumentException($"{target.Name} must not be empty.",
-                    target.Name);
+                throw new ArgumentException($"{target.Name} must not be empty.", target.Name);
 
             return target;
         }

--- a/wimm.Guardian/StringArgumentExtensions.cs
+++ b/wimm.Guardian/StringArgumentExtensions.cs
@@ -76,10 +76,7 @@ namespace wimm.Guardian
         /// </exception>
         public static Argument<string> IsNotEmpty(this Argument<string> target)
         {
-            if (target.Value == null)
-                return target;
-
-            if (target.Value.Length == 0)
+            if (target.Value?.Length == 0)
                 throw new ArgumentException($"{target.Name} must not be empty.", target.Name);
 
             return target;

--- a/wimm.Guardian/StringArgumentExtensions.cs
+++ b/wimm.Guardian/StringArgumentExtensions.cs
@@ -76,7 +76,7 @@ namespace wimm.Guardian
         /// </exception>
         public static Argument<string> IsNotEmpty(this Argument<string> target)
         {
-            if (target.Value == string.Empty)
+            if (target.Value.Length == 0)
                 throw new ArgumentException($"{target.Name} must not be empty.",
                     target.Name);
 

--- a/wimm.Guardian/StringArgumentRegexExtensions.cs
+++ b/wimm.Guardian/StringArgumentRegexExtensions.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 namespace wimm.Guardian
 {
     /// <summary>
-    /// TODO:CN
+    /// Validation arguments for strings that involve regex matching
     /// </summary>
     public static class StringArgumentRegexExtensions
     {


### PR DESCRIPTION
This PR is partially because I'm going to end up doing this and using it for a types lib and partially because I wanted to stem your whinging. 

This is the standard sort of Enum.IsDefined() argument. 

I've had to do a few things to support it:
netstd1.0 doesn't support the InvalidEnumArgumentException so instead we get the one in here. I'm not writing it out without autocomplete. 

There are a few QOL changes in here as well as well one of the tests for the string classes were failing and I wasn't sure when that started happening but it wasn't to spec so I fixed it up. I added the GlobalSuppression file to the gitignore and polished some stuff up that my linter was yelling at me for. 

If you're going to keep this going you should really set up a CI process of some sort so that I can't come in and break stuff whenever I want to. 

Finally. I would just like to point out that number of PR's I've made into your hobby projects is undefinededly higher than yours into mine 😛 