### PR TITLE
Validating that a combination of Enum Flags exist that could be combined together to get the input argument

### DIFF
--- a/wimm.Guardian.UnitTests/BitHelperTests.cs
+++ b/wimm.Guardian.UnitTests/BitHelperTests.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guardian.UnitTests
+{
+    [TestClass]
+    public class BitHelperTests
+    {
+
+
+
+        [DataTestMethod]
+        [DataRow(1,1)]
+        [DataRow(0, 0)]
+        [DataRow(-0, 0)]
+        [DataRow(-1, 32)]
+        [DataRow(127, 7)]
+        [DataRow(-128,25)]
+        [DataRow(int.MaxValue, 31)]
+        [DataRow(int.MinValue, 1)]
+        public void KernighanPopCount_ValidInt_ReturnsValidNumberOfBits(int input, int result)
+        {
+            Assert.AreEqual(result, BitHelpers.KernighanPopCount(input));
+        }
+
+        [DataTestMethod]
+        [DataRow(1, 1)]
+        [DataRow(0, 0)]
+        [DataRow(-0, 0)]
+        [DataRow(-1, 32)]
+        [DataRow(127, 7)]
+        [DataRow(-128, 25)]
+        [DataRow(int.MaxValue, 31)]
+        [DataRow(int.MinValue, 1)]
+        public void Popcount_ValidInt_ReturnsValidNumberOfBits(int input, int result)
+        {
+            Assert.AreEqual(result, BitHelpers.PopCount(input));
+        }
+
+
+
+        [DataTestMethod]
+        [DataRow(1L, 1)]
+        [DataRow(0L, 0)]
+        [DataRow(-0L, 0)]
+        [DataRow(-1L, 64)]
+        [DataRow(127L, 7)]
+        [DataRow(-128L, 57)]
+        [DataRow(long.MaxValue, 63)]
+        [DataRow(long.MinValue, 1)]
+        public void Popcount_ValidLong_ReturnsValidNumberOfBits(long input, int result)
+        {
+            Assert.AreEqual(result, BitHelpers.PopCount(input));
+        }
+
+
+    }
+}

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace wimm.Guardian.UnitTests
 {
@@ -44,9 +39,19 @@ namespace wimm.Guardian.UnitTests
         [TestMethod]
         public void IsFlagCombo_IsNotFlagCombo_Throws()
         {
-            var underTest = ((ValidSequential)0x1000).Require("MoreDoot");
+            var underTest = ((LongFlags)0x1000).Require("MoreDoot");
             Assert.ThrowsException<ArgumentException>(() => underTest.IsFlagCombo());
         }
+
+        [TestMethod]
+        public void IsFlagCombo_DuplicateEnumValues_ReturnsValueCopy()
+        {
+            var underTest = AliasedFlags.First.Require("SuchDoot");
+            var res = underTest.IsFlagCombo();
+
+            Assert.AreEqual(underTest.Value, res.Value);
+        }
+
 
         [TestMethod]
         public void IsFlagCombo_IsFlagCombo_ReturnsValueCopy()
@@ -64,17 +69,24 @@ namespace wimm.Guardian.UnitTests
         }
 
         [Flags]
-        private enum NonSequentialFlags
+        private enum ValidSequential
         {
             First = 0x1,
             Second = 0x10
         }
 
         [Flags]
-        private enum ValidSequential
+        private enum AliasedFlags
         {
             First = 0x1,
-            Second = 0x10
+            Second = First
+        }
+
+        [Flags]
+        private enum LongFlags :long
+        {
+            First = 0x1,
+            Second = 0x01
         }
     }
 

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -62,6 +62,25 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(underTest.Value, res.Value);
         }
 
+        [TestMethod]
+        public void IsFlagCombo_DifferentIntegralTypes_ReturnsValueCopy()
+        {
+            var shortTest = ShortFlags.Second.Require("Short");
+            var longTest = LongFlags.Second.Require("Long");
+            var byteTest = ByteFlags.Second.Require("Byte");
+            var unsignedTest = UnsignedFlags.Second.Require("Unsigned");
+
+            var shortResp = shortTest.IsFlagCombo();
+            var longResp = longTest.IsFlagCombo();
+            var byteResp = byteTest.IsFlagCombo();
+            var unsignedResp = unsignedTest.IsFlagCombo();
+
+            Assert.AreEqual(shortTest.Value, shortResp.Value);
+            Assert.AreEqual(longTest.Value, longResp.Value);
+            Assert.AreEqual(byteTest.Value, byteResp.Value);
+            Assert.AreEqual(unsignedTest.Value, unsignedResp.Value);
+        }
+
         private enum TestEnum
         {
             Yes,
@@ -88,7 +107,30 @@ namespace wimm.Guardian.UnitTests
             First = 0x1,
             Second = 0x01
         }
+
+        [Flags]
+        private enum ShortFlags : short
+        {
+            First = 0x1,
+            Second = 0x01
+        }
+
+        [Flags]
+        private enum ByteFlags : byte
+        {
+            First = 0x1,
+            Second = 0x01
+        }
+
+        //System.Enum
+        [Flags]
+        private enum UnsignedFlags : uint
+        {
+            First = 0x1,
+            Second = 0x01
+        }
     }
+    
 
 
 }

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -122,7 +122,6 @@ namespace wimm.Guardian.UnitTests
             Second = 0x01
         }
 
-        //System.Enum
         [Flags]
         private enum UnsignedFlags : uint
         {

--- a/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
+++ b/wimm.Guardian.UnitTests/EnumArgumentExtensionsTests.cs
@@ -34,10 +34,47 @@ namespace wimm.Guardian.UnitTests
             Assert.AreEqual(res.Value, underTest.Value);
         }
 
+        [TestMethod]
+        public void IsFlagCombo_NoFlagAttribute_Throws()
+        {
+            var underTest = TestEnum.Yes.Require("Doot");
+            Assert.ThrowsException<TypeArgumentException>(() => underTest.IsFlagCombo());
+        }
+
+        [TestMethod]
+        public void IsFlagCombo_IsNotFlagCombo_Throws()
+        {
+            var underTest = ((ValidSequential)0x1000).Require("MoreDoot");
+            Assert.ThrowsException<ArgumentException>(() => underTest.IsFlagCombo());
+        }
+
+        [TestMethod]
+        public void IsFlagCombo_IsFlagCombo_ReturnsValueCopy()
+        {
+            var underTest = (ValidSequential.First | ValidSequential.Second).Require("SoMuchDoot");
+            var res = underTest.IsFlagCombo();
+
+            Assert.AreEqual(underTest.Value, res.Value);
+        }
+
         private enum TestEnum
         {
             Yes,
             No
+        }
+
+        [Flags]
+        private enum NonSequentialFlags
+        {
+            First = 0x1,
+            Second = 0x10
+        }
+
+        [Flags]
+        private enum ValidSequential
+        {
+            First = 0x1,
+            Second = 0x10
         }
     }
 

--- a/wimm.Guardian.UnitTests/GenericExtensionTest.cs
+++ b/wimm.Guardian.UnitTests/GenericExtensionTest.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guardian.UnitTests
+{
+    [TestClass]
+    public class GenericExtensionTest
+    {
+
+        [TestMethod]
+        public void HasAttribute_DoesNotHaveAttribute_Throws()
+        {
+            var underTest = new NoAttribute();
+            Assert.ThrowsException<TypeArgumentException>(() =>
+                underTest.Require(nameof(underTest)).HasAttribute(typeof(SerializableAttribute)));
+        }
+
+        [TestMethod]
+        public void HasAttribute_TypeHasAttribute_ReturnsType()
+        {
+            var underTest = new TestClass();
+            var value = underTest.Require(nameof(underTest)).HasAttribute(typeof(SerializableAttribute));
+            Assert.AreSame(underTest, value.Value);
+        }
+
+        [Serializable]
+        private class TestClass
+        {
+            public int i = 0;
+        }
+
+        private class NoAttribute
+        {
+            public int i = 0;
+        }
+    }
+}

--- a/wimm.Guardian.UnitTests/GenericExtensionTest.cs
+++ b/wimm.Guardian.UnitTests/GenericExtensionTest.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace wimm.Guardian.UnitTests
 {

--- a/wimm.Guardian/BitHelpers.cs
+++ b/wimm.Guardian/BitHelpers.cs
@@ -37,10 +37,6 @@ namespace wimm.Guardian
             return PopCount((int)toCount) + PopCount((int)(toCount >> 32));
         }
 
-
-
-
-
         public static int KernighanPopCount(int toCount)
         {
             var count = 0;

--- a/wimm.Guardian/BitHelpers.cs
+++ b/wimm.Guardian/BitHelpers.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace wimm.Guardian
+{
+    internal static class BitHelpers
+    {
+        private static readonly int[] _popCountTableSigned;
+        private static readonly int[] _popCountTableUnsigned;
+
+
+        static BitHelpers()
+        {
+            _popCountTableSigned = new int[256];
+            _popCountTableUnsigned = new int[256];
+
+            for (int i = 0; i < 256; i++)
+            {
+                _popCountTableSigned[i] = KernighanPopCount(i);
+            }
+        }
+
+        public static int PopCount(int toCount)
+        {
+            
+            return _popCountTableSigned[toCount & 0xFF]
+                + _popCountTableSigned[(toCount >> 8) & 0xFF]
+                + _popCountTableSigned[(toCount >> 16) & 0xFF]
+                + _popCountTableSigned[(toCount >> 24) & 0xFF];
+        }
+
+        public static int PopCount(long toCount)
+        {
+            return PopCount((int)toCount) + PopCount((int)(toCount >> 32));
+        }
+
+
+
+
+
+        public static int KernighanPopCount(int toCount)
+        {
+            var count = 0;
+
+            while (toCount != 0)
+            {
+                toCount &= toCount - 1;
+                count++;
+            }
+
+            return count;
+        }
+
+    }
+}

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -26,8 +26,7 @@ namespace wimm.Guardian
         public static Argument<T> IsDefinedEnum<T>(this Argument<T> argument) 
             where T : struct, IComparable
         {
-            if (!typeof(T).GetTypeInfo().IsEnum)
-                throw new TypeArgumentException(nameof(T), typeof(T));
+            argument.IsEnum();
 
             if (!Enum.IsDefined(typeof(T), argument.Value))
                 throw new EnumArgumentOutOfRangeException(

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -43,7 +43,7 @@ namespace wimm.Guardian
         /// <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T">A <see cref="FlagsAttribute"/> tagged <see cref="Enum"/></typeparam>
-        /// <param name="argument"> And argument containing the value to be checked </param>
+        /// <param name="argument"> An argument containing the value to be checked </param>
         /// <returns> A copy of the input <see cref="Argument{T}"/></returns>
         /// <exception cref="TypeArgumentException"> 
         /// The underlying type of <typeparamref name="T"/>is not <see cref="int"/> or <see cref="long"/>

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -60,9 +60,7 @@ namespace wimm.Guardian
 
             argument.HasAttribute(typeof(FlagsAttribute));
 
-            var underlyingType = Enum.GetUnderlyingType(type);
-
-            long[] values = FlagsToArray(type, underlyingType);
+            long[] values = FlagsToArray(type);
 
             if (values.Any(x => BitHelpers.PopCount(x) != 1))
                 throw new TypeArgumentException(argument.Name, type, "Each flag must only have a single bit set");
@@ -99,7 +97,7 @@ namespace wimm.Guardian
 
         }
 
-        private static long[] FlagsToArray(Type enumType, Type underlyingType)
+        private static long[] FlagsToArray(Type enumType)
         {
             var values = Enum.GetValues(enumType);
             var arr = new long[values.Length];

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -38,11 +38,26 @@ namespace wimm.Guardian
         }
 
         /// <summary>
-        /// TODO:I47
+        /// Throws an <see cref="ArgumentException"/> if the value of <paramref name="argument"/> cannot
+        /// be composed of values of the <see cref="FlagsAttribute"/> tagged <see cref="Enum"/> 
+        /// <typeparamref name="T"/>
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="argument"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">A <see cref="FlagsAttribute"/> tagged <see cref="Enum"/></typeparam>
+        /// <param name="argument"> And argument containing the value to be checked </param>
+        /// <returns> A copy of the input <see cref="Argument{T}"/></returns>
+        /// <exception cref="TypeArgumentException"> 
+        /// The underlying type of <typeparamref name="T"/>is not <see cref="int"/> or <see cref="long"/>
+        /// </exception>
+        /// <exception cref="TypeArgumentException"> 
+        /// <typeparamref name="T"/> does not possess the <see cref="FlagsAttribute"/>
+        /// </exception>
+        /// <exception cref="TypeArgumentException">
+        /// The flag values of <typeparamref name="T"/> are not individual bits
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The value <paramref name="argument"/> is not composable from individual flags of the input type
+        /// <typeparamref name="T"/>
+        /// </exception>
         public static Argument<T> IsFlagCombo<T>(this Argument<T> argument) where T : struct, IComparable
         {
             var type = typeof(T);

--- a/wimm.Guardian/EnumArgumentExtensions.cs
+++ b/wimm.Guardian/EnumArgumentExtensions.cs
@@ -60,10 +60,7 @@ namespace wimm.Guardian
 
             argument.HasAttribute(typeof(FlagsAttribute));
 
-            long[] values = FlagsToArray(type);
-
-            if (values.Any(x => BitHelpers.PopCount(x) != 1))
-                throw new TypeArgumentException(argument.Name, type, "Each flag must only have a single bit set");
+            var values = FlagsToArray(type);
 
             var asLong = Convert.ToInt64(argument.Value);
 

--- a/wimm.Guardian/GenericExtensions.cs
+++ b/wimm.Guardian/GenericExtensions.cs
@@ -1,4 +1,11 @@
-﻿namespace wimm.Guardian
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+//TODO:I47 -> Remove eventually, or not
+[assembly:InternalsVisibleTo("wimm.Guardian.UnitTests")]
+
+namespace wimm.Guardian
 {
     internal static class GenericExtensions
     {
@@ -6,6 +13,15 @@
         {
             if (default(T) == null)
                 argument.IsNotNull();
+        }
+
+        //TODO:I47 -> Internal for now until tested and doc'd
+        internal static Argument<T> HasAttribute<T>(this Argument<T> argument, Type attributeType)
+        {
+            var attribute = typeof(T).GetTypeInfo().GetCustomAttribute(attributeType)
+                ?? throw new TypeArgumentException(argument.Name, typeof(T));
+
+            return argument;
         }
     }
 }

--- a/wimm.Guardian/TypeArgumentException.cs
+++ b/wimm.Guardian/TypeArgumentException.cs
@@ -18,7 +18,13 @@ namespace wimm.Guardian
         public Type Type { get; }
 
         internal TypeArgumentException(string typeParamName, Type type)
-            : base($"{typeParamName} does not supported type {type.FullName}.")
+            : this(typeParamName, type, null)
+        {
+
+        }
+
+        internal TypeArgumentException(string typeParamName, Type type, string additionalMessage)
+            : base($"{typeParamName} does not support type {type.FullName}.{additionalMessage ?? string.Empty}")
         {
             TypeParamName = typeParamName.Require(nameof(typeParamName)).IsNotNull().Value;
             Type = type.Require(nameof(type)).IsNotNull().Value;

--- a/wimm.Guardian/wimm.Guardian.csproj
+++ b/wimm.Guardian/wimm.Guardian.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>0.1.0</Version>

--- a/wimm.Guardian/wimm.Guardian.csproj
+++ b/wimm.Guardian/wimm.Guardian.csproj
@@ -9,9 +9,9 @@
     <AssemblyVersion>0.2.1.0</AssemblyVersion>
     <FileVersion>0.2.1.0</FileVersion>
     <PackageTags>Validation, Arguments, Guard</PackageTags>
-    <Authors>Thomas Showers</Authors>
+    <Authors>Thomas Showers, Chris Nantau</Authors>
     <Company>wareismymind</Company>
-    <PackageLicenseUrl>https://github.com/wareismymind/Guardian/blob/release/0.1/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/wareismymind/Guardian/blob/release/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/wareismymind/Guardian</PackageProjectUrl>
     <RepositoryUrl>https://github.com/wareismymind/Guardian</RepositoryUrl>
     <PackageReleaseNotes>- Removes 'ISubject' to focus on argument validation.</PackageReleaseNotes>

--- a/wimm.Guardian/wimm.Guardian.csproj
+++ b/wimm.Guardian/wimm.Guardian.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>0.3.0</Version>
+    <Version>0.1.0</Version>
     <Copyright>Copyright 2017 (c) Thomas Showers. All rights reserved.</Copyright>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <FileVersion>0.2.1.0</FileVersion>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
     <PackageTags>Validation, Arguments, Guard</PackageTags>
     <Authors>Thomas Showers, Chris Nantau</Authors>
     <Company>wareismymind</Company>


### PR DESCRIPTION
Well this one is probably a bit of overkill but I figured if I was already creating the enum checking code I may as well do this one as well. 

So this checks that: 
An enum value passed in as a flagged value has: 
* Values that only take up one bit
* The [Flags] attribute on the type
* Is backed by an int or long
* Is composed of those flag values. 

Required creating some popcnt algorithms because I can't just use the intrinsics. Also added an augmenting message to TypeArgumentException. Also created .HasAttribute but made it internal temporarily because I didn't want to do all the documentation in this PR. Same with IsEnum(). 
