### PR TITLE
Use <GenerateDocumentationFile>true></...>

### DIFF
--- a/wimm.Guardian/wimm.Guardian.csproj
+++ b/wimm.Guardian/wimm.Guardian.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>0.1.0</Version>
     <Copyright>Copyright 2017 (c) Thomas Showers. All rights reserved.</Copyright>
@@ -32,19 +33,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard1.0\wimm.Guardian.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.0\wimm.Guardian.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
-    <DocumentationFile>bin\Debug\net45\wimm.Guardian.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
-    <DocumentationFile>bin\Release\net45\wimm.Guardian.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="BitHelpers.cs" />
     <Compile Remove="Requirement.cs" />


### PR DESCRIPTION
The <DocumentationFile> tags were specifying net45 and netstandard1.0,
but we've moved to 1.3 so they no longer work for the .netstandard
build. Switching to <GenerateDocumentationFile> makes the documentation
work for all targets.

closes #14 